### PR TITLE
Fix migration for Rails 5

### DIFF
--- a/db/migrate/20150415193853_create_users.rb
+++ b/db/migrate/20150415193853_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
 


### PR DESCRIPTION
Directly inheriting from ActiveRecord::Migration is not supported. We must specify the Rails release the migration was written for.